### PR TITLE
Additions on top of Numba PR #5900

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -122,16 +122,24 @@ def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
 
 
 @require_context
-def managed_array(shape, dtype=np.float, strides=None, order='C', stream=0):
-    """managed_array(shape, dtype=np.float, strides=None, order='C')
+def managed_array(shape, dtype=np.float, strides=None, order='C', stream=0,
+                  attach_global=True):
+    """managed_array(shape, dtype=np.float, strides=None, order='C', stream=0, attach_global=True)
 
     Allocate a np.ndarray with a buffer that is managed.
     Similar to np.empty().
+
+    :param attach_global: A flag indicating whether to attach globally. Global
+                          attachment implies that the memory is accessible from
+                          any stream on any device. If ``False``, attachment is
+                          *host*, and memory is only accessible by devices
+                          with Compute Capability 6.0 and later.
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)
     bytesize = driver.memory_size_from_info(shape, strides, dtype.itemsize)
-    buffer = current_context().memallocmanaged(bytesize)
+    buffer = current_context().memallocmanaged(bytesize,
+                                               attach_global=attach_global)
     npary = np.ndarray(shape=shape, strides=strides, dtype=dtype, order=order,
                       buffer=buffer)
     managedview = np.ndarray.view(npary, type=devicearray.ManagedNDArray)

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -122,7 +122,7 @@ def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
 
 
 @require_context
-def managed_array(shape, dtype=np.float, strides=None, order='C'):
+def managed_array(shape, dtype=np.float, strides=None, order='C', stream=0):
     """managed_array(shape, dtype=np.float, strides=None, order='C')
 
     Allocate a np.ndarray with a buffer that is managed.
@@ -130,11 +130,13 @@ def managed_array(shape, dtype=np.float, strides=None, order='C'):
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)
-    bytesize = driver.memory_size_from_info(shape, strides,
-                                            dtype.itemsize)
+    bytesize = driver.memory_size_from_info(shape, strides, dtype.itemsize)
     buffer = current_context().memallocmanaged(bytesize)
-    return np.ndarray(shape=shape, strides=strides, dtype=dtype, order=order,
+    npary = np.ndarray(shape=shape, strides=strides, dtype=dtype, order=order,
                       buffer=buffer)
+    managedview = np.ndarray.view(npary, type=devicearray.ManagedNDArray)
+    managedview.device_setup(buffer, stream=stream)
+    return managedview
 
 
 @require_context

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -682,6 +682,15 @@ class MappedNDArray(DeviceNDArrayBase, np.ndarray):
         self.gpu_data = gpu_data
 
 
+class ManagedNDArray(DeviceNDArrayBase, np.ndarray):
+    """
+    A host array that uses CUDA managed memory.
+    """
+
+    def device_setup(self, gpu_data, stream=0):
+        self.gpu_data = gpu_data
+
+
 def from_array_like(ary, stream=0, gpu_data=None):
     "Create a DeviceNDArray object that is like ary."
     return DeviceNDArray(ary.shape, ary.strides, ary.dtype,

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1682,7 +1682,7 @@ class AutoFreePointer(MemoryPointer):
 
 
 class MappedMemory(AutoFreePointer):
-    """A memory pointer that owns a buffer on the host that is mapped into
+    """A memory pointer that refers to a buffer on the host that is mapped into
     device memory.
 
     :param context: The context in which the pointer was mapped.
@@ -1760,8 +1760,8 @@ class PinnedMemory(mviewbuf.MemAlloc):
 
 
 class ManagedMemory(AutoFreePointer):
-    """A memory pointer that owns a managed memory buffer (can be accessed on both
-    host and device).
+    """A memory pointer that refers to a managed memory buffer (can be accessed
+    on both host and device).
 
     :param context: The context in which the pointer was mapped.
     :type context: Context

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -790,6 +790,26 @@ class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
             return PinnedMemory(ctx, pointer, size, owner=owner,
                                 finalizer=finalizer)
 
+    def memallocmanaged(self, size, attach_global):
+        ptr = drvapi.cu_device_ptr()
+
+        def allocator():
+            flags = c_uint()
+            if attach_global:
+                flags = enums.CU_MEM_ATTACH_GLOBAL
+            else:
+                flags = enums.CU_MEM_ATTACH_HOST
+
+            driver.cuMemAllocManaged(byref(ptr), size, flags)
+
+        self._attempt_allocation(allocator)
+
+        finalizer = _alloc_finalizer(self, ptr, size)
+        ctx = weakref.proxy(self.context)
+        mem = ManagedMemory(ctx, ptr, size, finalizer=finalizer)
+        self.allocations[ptr.value] = mem
+        return mem.own()
+
     def reset(self):
         """Clears up all host memory (mapped and/or pinned) in the current
         context.
@@ -853,26 +873,6 @@ class NumbaCUDAMemoryManager(GetIpcHandleMixin, HostOnlyCUDAMemoryManager):
         finalizer = _alloc_finalizer(self, ptr, size)
         ctx = weakref.proxy(self.context)
         mem = AutoFreePointer(ctx, ptr, size, finalizer=finalizer)
-        self.allocations[ptr.value] = mem
-        return mem.own()
-
-    def memallocmanaged(self, size, attach_global):
-        ptr = drvapi.cu_device_ptr()
-
-        def allocator():
-            flags = c_uint()
-            if attach_global:
-                flags = enums.CU_MEM_ATTACH_GLOBAL
-            else:
-                flags = enums.CU_MEM_ATTACH_HOST
-
-            driver.cuMemAllocManaged(byref(ptr), size, flags)
-
-        self._attempt_allocation(allocator)
-
-        finalizer = _alloc_finalizer(self, ptr, size)
-        ctx = weakref.proxy(self.context)
-        mem = ManagedMemory(ctx, ptr, size, finalizer=finalizer)
         self.allocations[ptr.value] = mem
         return mem.own()
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1791,7 +1791,7 @@ class ManagedMemory(AutoFreePointer):
         self._bufptr_ = self.device_pointer.value
 
     def own(self):
-        return ManagedPointer(weakref.proxy(self))
+        return ManagedOwnedPointer(weakref.proxy(self))
 
 
 class OwnedPointer(object):
@@ -1829,7 +1829,7 @@ class MappedOwnedPointer(OwnedPointer, mviewbuf.MemAlloc):
     pass
 
 
-class ManagedPointer(OwnedPointer, mviewbuf.MemAlloc):
+class ManagedOwnedPointer(OwnedPointer, mviewbuf.MemAlloc):
     pass
 
 

--- a/numba/cuda/cudadrv/enums.py
+++ b/numba/cuda/cudadrv/enums.py
@@ -114,13 +114,15 @@ CU_MEMHOSTREGISTER_PORTABLE = 0x01
 CU_MEMHOSTREGISTER_DEVICEMAP = 0x02
 
 
-# If set, managed memory is accessible from all streams on
-# all devices.
+# If set, managed memory is accessible from all streams on all devices.
 CU_MEM_ATTACH_GLOBAL = 0x01
 
-# If set, managed memory is not accessible from all streams on
-# all devices.
+# If set, managed memory is not accessible from any stream on any device.
 CU_MEM_ATTACH_HOST = 0x02
+
+# If set, managed memory is only accessible from a single stream on the
+# associated device.
+CU_MEM_ATTACH_SINGLE = 0x04
 
 
 # Default event flag

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -44,6 +44,15 @@ class TestManagedAlloc(ContextResettingTestCase):
         self.skip_if_cc_major_lt(3, msg)
         self._test_managed_alloc_driver(0.5)
 
+    # This test is skipped by default because it is easy to hang the machine
+    # for a very long time or get OOM killed if the GPU memory size is >50% of
+    # the system memory size. Even if the system does have more than 2x the RAM
+    # of the GPU, this test runs for a very long time (in comparison to the
+    # rest of the tests in the suite).
+    #
+    # However, it is left in here for manual testing as required.
+
+    @unittest.skip
     def test_managed_alloc_driver_oversubscribe(self):
         msg = "Oversubscription of managed memory unsupported prior to CC 6.0"
         self.skip_if_cc_major_lt(6, msg)

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -1,6 +1,7 @@
 import numpy as np
 import platform
-from numba.cuda.cudadrv import driver
+from ctypes import byref, c_size_t
+from numba.cuda.cudadrv.driver import device_memset, driver
 from numba import cuda
 from numba.cuda.testing import unittest, ContextResettingTestCase
 from numba.cuda.testing import skip_on_cudasim
@@ -8,46 +9,65 @@ from numba.cuda.testing import skip_on_cudasim
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
 class TestManagedAlloc(ContextResettingTestCase):
-    def test_managed_alloc_driver(self):
+
+    def get_total_gpu_memory(self):
+        # We use a driver function to directly get the total GPU memory because
+        # an EMM plugin may report something different (or not implement
+        # get_memory_info at all).
+        free = c_size_t()
+        total = c_size_t()
+        driver.cuMemGetInfo(byref(free), byref(total))
+        return total.value
+
+    def skip_if_cc_major_lt(self, min_required, reason):
+        """
+        Skip the current test if the compute capability of the device is
+        less than `min_required`.
+        """
+        ctx = cuda.current_context()
+        cc_major = ctx.device.compute_capability[0]
+        if cc_major < min_required:
+            self.skipTest(reason)
+
+    # CUDA Unified Memory comes in two flavors. For GPUs in the Kepler and
+    # Maxwell generations, managed memory allocations work as opaque,
+    # contiguous segments that can either be on the device or the host. For
+    # GPUs in the Pascal or later generations, managed memory operates on a
+    # per-page basis, so we can have arrays larger than GPU memory, where only
+    # part of them is resident on the device at one time. To ensure that this
+    # test works correctly on all supported GPUs, we'll select the size of our
+    # memory such that we only oversubscribe the GPU memory if we're on a
+    # Pascal or newer GPU (compute capability at least 6.0).
+
+    def test_managed_alloc_driver_undersubscribe(self):
+        msg = "Managed memory unsupported prior to CC 3.0"
+        self.skip_if_cc_major_lt(3, msg)
+        self._test_managed_alloc_driver(0.5)
+
+    def test_managed_alloc_driver_oversubscribe(self):
+        msg = "Oversubscription of managed memory unsupported prior to CC 6.0"
+        self.skip_if_cc_major_lt(6, msg)
+        if platform.system() != "Linux":
+            msg = "Oversubscription of managed memory only supported on Linux"
+            self.skipTest(msg)
+        self._test_managed_alloc_driver(2.0)
+
+    def _test_managed_alloc_driver(self, memory_factor):
         # Verify that we can allocate and operate on managed
         # memory through the CUDA driver interface.
 
+        total_mem_size = self.get_total_gpu_memory()
+        n_bytes = int(memory_factor * total_mem_size)
+
         ctx = cuda.current_context()
-
-        # CUDA Unified Memory comes in two flavors. For GPUs in the
-        # NVIDIA Kepler and Maxwell generations, managed memory
-        # allocations work as opaque, contiguous segments that can
-        # either be on the device or the host. For GPUs in the Pascal
-        # or later generations, managed memory operates on a per-page
-        # basis, so we can have arrays larger than GPU memory, where
-        # only part of them is resident on the device at one time. To
-        # ensure that this test works correctly on all supported GPUs,
-        # we'll select the size of our memory such that we only
-        # oversubscribe the GPU memory if we're on a Pascal or newer GPU
-        # (compute capability at least 6.0).
-
-        compute_capability_major = ctx.device.compute_capability[0]
-
-        # This test is unsupported on GPUs prior to the Kepler generation.
-
-        self.assertGreaterEqual(compute_capability_major, 3)
-
-        total_mem_size = ctx.get_memory_info().total
-
-        if compute_capability_major >= 6 and platform.system() == 'Linux':
-            n_bytes = int(2 * total_mem_size)
-        else:
-            n_bytes = int(0.5 * total_mem_size)
+        mem = ctx.memallocmanaged(n_bytes)
 
         dtype = np.dtype(np.uint8)
         n_elems = n_bytes // dtype.itemsize
-
-        mem = ctx.memallocmanaged(n_bytes)
-
         ary = np.ndarray(shape=n_elems, dtype=dtype, buffer=mem)
 
         magic = 0xab
-        driver.device_memset(mem, magic, n_bytes)
+        device_memset(mem, magic, n_bytes)
         ctx.synchronize()
 
         # Note that this assertion operates on the CPU, so this

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -61,7 +61,14 @@ class TestManagedAlloc(ContextResettingTestCase):
             self.skipTest(msg)
         self._test_managed_alloc_driver(2.0)
 
-    def _test_managed_alloc_driver(self, memory_factor):
+    def test_managed_alloc_driver_host_attach(self):
+        msg = "Host attached managed memory is not accessible prior to CC 6.0"
+        self.skip_if_cc_major_lt(6, msg)
+        # Only test with a small array (0.01 * memory size) to keep the test
+        # quick.
+        self._test_managed_alloc_driver(0.01, attach_global=False)
+
+    def _test_managed_alloc_driver(self, memory_factor, attach_global=True):
         # Verify that we can allocate and operate on managed
         # memory through the CUDA driver interface.
 
@@ -69,7 +76,7 @@ class TestManagedAlloc(ContextResettingTestCase):
         n_bytes = int(memory_factor * total_mem_size)
 
         ctx = cuda.current_context()
-        mem = ctx.memallocmanaged(n_bytes)
+        mem = ctx.memallocmanaged(n_bytes, attach_global=attach_global)
 
         dtype = np.dtype(np.uint8)
         n_elems = n_bytes // dtype.itemsize

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -92,7 +92,7 @@ class TestManagedAlloc(ContextResettingTestCase):
 
         self.assertTrue(np.all(ary == magic))
 
-    def test_managed_array(self):
+    def _test_managed_array(self, attach_global=True):
         # Check the managed_array interface on both host and device.
 
         ary = cuda.managed_array(100, dtype=np.double)
@@ -109,6 +109,15 @@ class TestManagedAlloc(ContextResettingTestCase):
         cuda.current_context().synchronize()
 
         self.assertTrue(all(ary == 1.0))
+
+    def test_managed_array_attach_global(self):
+        self._test_managed_array()
+
+    def test_managed_array_attach_host(self):
+        self._test_managed_array()
+        msg = "Host attached managed memory is not accessible prior to CC 6.0"
+        self.skip_if_cc_major_lt(6, msg)
+        self._test_managed_array(attach_global=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
cc @maxpkatz - as detailed in https://github.com/numba/numba/pull/5900#issuecomment-690355929

Additionally, this includes a test of `attach_global=False`, and exposes it in `cuda.managed_array`.