### PR TITLE
Allow NVRTC to compile cuda source files to ltoir

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -2642,18 +2642,18 @@ class Linker(metaclass=ABCMeta):
     def add_file(self, path, kind):
         """Add code from a file to the link"""
 
-    def add_cu_file(self, path):
+    def add_cu_file(self, path, link_lto=False):
         with open(path, 'rb') as f:
             cu = f.read()
-        self.add_cu(cu, os.path.basename(path))
+        self.add_cu(cu, os.path.basename(path), link_lto=link_lto)
 
-    def add_file_guess_ext(self, path):
+    def add_file_guess_ext(self, path, link_lto=False):
         """Add a file to the link, guessing its type from its extension."""
         ext = os.path.splitext(path)[1][1:]
         if ext == '':
             raise RuntimeError("Don't know how to link file with no extension")
         elif ext == 'cu':
-            self.add_cu_file(path)
+            self.add_cu_file(path, link_lto)
         else:
             kind = FILE_EXTENSION_MAP.get(ext, None)
             if kind is None:

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -629,6 +629,8 @@ def compile_ir(llvmir, **opts):
         cu.add_module(mod.encode('utf8'))
     cu.lazy_add_module(libdevice.get())
 
+    print("nvvm compile opts: ", opts)
+
     return cu.compile(**opts)
 
 


### PR DESCRIPTION
Currently NVRTC always compile cuda source file to ltoir. This PR enables that cuda source files are compiled into LTOIR.

There are a few things that needs be discussed

- `link_lto` flag will toggle a global on/off switch for all cuda source in `link` list. Is this what we want?
- Currently still fails to jit.

Testing with this example:
```
@cuda.jit(link=["extern.cu"], link_lto=True)
def kernel(arr):
    i = cuda.grid(1)
    arr[i] = add(i, i)

// extern.cu
__device__ int add(int a, int b)
{
    return a + b;
}
```

Error:
```
Traceback (most recent call last):
  File "/home/wangm/pynvjitlink/pynvjitlink/api.py", line 83, in get_linked_cubin
    _nvjitlinklib.complete(self.handle)
RuntimeError: NVJITLINK_ERROR_PTX_COMPILE error when calling nvJitLinkComplete

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/wangm/pynvjitlink/pynvjitlink/patch.py", line 229, in complete
    cubin = self._linker.get_linked_cubin()
  File "/home/wangm/pynvjitlink/pynvjitlink/api.py", line 88, in get_linked_cubin
    raise NvJitLinkError(f"{e}\n{self.error_log}")
pynvjitlink.api.NvJitLinkError: NVJITLINK_ERROR_PTX_COMPILE error when calling nvJitLinkComplete
ptxas fatal   : Unresolved extern function 'add'
ERROR NVJITLINK_ERROR_PTX_COMPILE: JIT the PTX (ltoPtx)


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/wangm/numbast/scratch/031124/small.py", line 20, in <module>
    kernel[1, 10](arr)
  File "/home/wangm/numba/numba/cuda/dispatcher.py", line 541, in __call__
    return self.dispatcher.call(args, self.griddim, self.blockdim,
  File "/home/wangm/numba/numba/cuda/dispatcher.py", line 675, in call
    kernel = _dispatcher.Dispatcher._cuda_call(self, *args)
  File "/home/wangm/numba/numba/cuda/dispatcher.py", line 683, in _compile_for_args
    return self.compile(tuple(argtypes))
  File "/home/wangm/numba/numba/cuda/dispatcher.py", line 928, in compile
    kernel.bind()
  File "/home/wangm/numba/numba/cuda/dispatcher.py", line 199, in bind
    self._codelibrary.get_cufunc(link_lto=self.link_lto)
  File "/home/wangm/numba/numba/cuda/codegen.py", line 213, in get_cufunc
    cubin = self.get_cubin(cc=device.compute_capability, link_lto=link_lto)
  File "/home/wangm/numba/numba/cuda/codegen.py", line 194, in get_cubin
    cubin = linker.complete()
  File "/home/wangm/pynvjitlink/pynvjitlink/patch.py", line 233, in complete
    raise LinkerError from e
numba.cuda.cudadrv.driver.LinkerError
```